### PR TITLE
Changed host for stats.darmstadt.freifunk.net

### DIFF
--- a/zones/zonefiles/darmstadt.freifunk.net.zone
+++ b/zones/zonefiles/darmstadt.freifunk.net.zone
@@ -1,7 +1,7 @@
 $TTL 3600
 $ORIGIN darmstadt.freifunk.net.
 @    IN    SOA    ns1.darmstadt.freifunk.net. info.darmstadt.freifunk.net. (
-                2016020201 ; Serial - date by convention
+                2016021201 ; Serial - date by convention
                 10800      ; Refresh
                 600        ; Retry
                 604800     ; Expire

--- a/zones/zonefiles/darmstadt.freifunk.net.zone
+++ b/zones/zonefiles/darmstadt.freifunk.net.zone
@@ -65,7 +65,7 @@ lg          CNAME gw04
 map         CNAME gw04
 mumble      CNAME srv01
 oldwiki     CNAME srv01
-stats       CNAME graphite.rammhold.de.
+stats       CNAME graphite.h4ck.space.
 taiga       CNAME srv02
 tickets     CNAME srv03
 spenden     CNAME gw04


### PR DESCRIPTION
Needs to be coordinated with gateway telemetry script changes.
